### PR TITLE
updated scripts to fix a bug

### DIFF
--- a/Arch/kde/README.md
+++ b/Arch/kde/README.md
@@ -14,3 +14,14 @@ These scripts were made after realising that for my KDE Plasma setup,
 - pacman was showing errors regarding the XferCommand line, the reasons for which are yet to be understood by me.
 
 I also wanted to make the script change Firefox's proxy settings.
+
+---
+
+## Changelog
+**1)** remove_proxy.sh doesnt unset proxy variables from terminal (noticed from the fact that 'git push' never worked after removing proxy).
+- apply_proxy.sh modifies the ~/.bashrc file to make it so that proxy variables are loaded back in for every terminal and for every kde login session.
+- modified remove_proxy.sh such that it removes from current kde login session perfectly.
+- test by running ```bash env | grep -i proxy``` in terminal before and after running remove_proxy.sh, proxy variables used to still be stored, new scripts make sure they dont.
+
+
+

--- a/Arch/kde/apply_proxy
+++ b/Arch/kde/apply_proxy
@@ -42,6 +42,8 @@ PROXY_HTTP="http://${AUTH}${PROXY_HOST}:${PROXY_PORT}"
 #################################
 # System environment
 #################################
+echo ""
+echo "Configuring environment variables...."
 
 sudo tee /etc/profile.d/proxy.sh >/dev/null <<EOF
 export http_proxy="$PROXY_HTTP"
@@ -52,6 +54,11 @@ export ftp_proxy="$PROXY_HTTP"
 export no_proxy="localhost,127.0.0.1,::1"
 EOF
 
+#Push variables to the active systemd and D-Bus session
+systemctl --user set-environment http_proxy="$PROXY_HTTP" https_proxy="$PROXY_HTTP" HTTP_PROXY="$PROXY_HTTP" HTTPS_PROXY="$PROXY_HTTP" ftp_proxy="$PROXY_HTTP" no_proxy="localhost,127.0.0.1,::1"
+dbus-update-activation-environment --systemd http_proxy https_proxy HTTP_PROXY HTTPS_PROXY ftp_proxy no_proxy
+
+echo "Done!!"
 #################################
 # pacman
 #################################
@@ -64,24 +71,29 @@ if [[ ! -f /etc/sudoers.d/proxy ]]; then
     sudo chmod 440 /etc/sudoers.d/proxy
 fi
 
+echo""
 #################################
 # git
 #################################
+echo "Configuring git...."
 
 git config --global http.proxy "$PROXY_HTTP"
 git config --global https.proxy "$PROXY_HTTP"
 
+echo "Done!!"
 #################################
 # npm
 #################################
+echo "Configuring npm...."
 
 npm config set proxy "$PROXY_HTTP"
 npm config set https-proxy "$PROXY_HTTP"
 
+echo "Done!!"
 #################################
 # KDE Plasma GUI (Plasma 6)
 #################################
-
+echo "Configuring KDE Plasma...."
 # Use Plasma 6 tools
 KWRITE=kwriteconfig6
 
@@ -95,15 +107,19 @@ $KWRITE --file kioslaverc --group "Proxy Settings" --key ProxyPass "$PROXY_PASS"
 # Optional reload (may fail silently, that's fine)
 qdbus6 org.kde.KIO.Scheduler /KIO/Scheduler reparseSlaveConfiguration 2>/dev/null || true
 
+echo "Done!!"
 #################################
 # snap
 #################################
+echo "Configuring snap...."
 
 sudo systemctl restart snapd 2>/dev/null || true
 
+echo "Done!!"
 #################################
 # Firefox
 #################################
+echo "Configuring Firefox...."
 
 FF_PROFILE="$HOME/.mozilla/firefox/r3my975k.default-release"
 
@@ -117,5 +133,7 @@ user_pref("network.proxy.share_proxy_settings", true);
 user_pref("network.proxy.no_proxies_on", "localhost, 127.0.0.1");
 EOF
 
+echo "Done!!"
 echo
 echo "Proxy enabled!!"
+

--- a/Arch/kde/remove_proxy
+++ b/Arch/kde/remove_proxy
@@ -11,26 +11,36 @@ echo "=== Disable Proxy ==="
 #################################
 # System env
 #################################
+echo ""
+echo "Removing env varibles...."
 
 sudo rm -f /etc/profile.d/proxy.sh
+
+echo "Done"
 
 #################################
 # git
 #################################
+echo "Removing from git...."
 
 git config --global --unset http.proxy || true
 git config --global --unset https.proxy || true
 
+
+echo "Done"
 #################################
 # npm
 #################################
+echo "Removing from npm...."
 
 npm config delete proxy || true
 npm config delete https-proxy || true
 
+echo "Done"
 #################################
 # KDE Plasma GUI (Plasma 6)
 #################################
+echo "Removing from KDE Plasma...."
 
 # Use Plasma 6 tools
 KWRITE=kwriteconfig6
@@ -46,15 +56,19 @@ $KWRITE --file kioslaverc --group "Proxy Settings" --key socksProxy ""
 # Optional reload (may fail silently, that's fine)
 qdbus6 org.kde.KIO.Scheduler /KIO/Scheduler reparseSlaveConfiguration 2>/dev/null || true
 
+echo "Done"
 #################################
 # snap
 #################################
+echo "Removing from snap...."
 
 sudo systemctl restart snapd 2>/dev/null || true
 
+echo "Done"
 #################################
 # Firefox
 #################################
+echo "Removing from Firefox...."
 
 FF_PROFILE="/home/poke/.mozilla/firefox/r3my975k.default-release"
 
@@ -62,6 +76,20 @@ cat > "$FF_PROFILE/user.js" <<EOF
 user_pref("network.proxy.type", 0);
 EOF
 
+#################################
+# Current shell + systemd env
+#################################
+echo "Removing from current session environment...."
 
-echo
+# unset in the current terminal
+unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY ftp_proxy no_proxy
+
+# wipe from the active KDE D-Bus session
+dbus-update-activation-environment --systemd http_proxy="" https_proxy="" HTTP_PROXY="" HTTPS_PROXY="" ftp_proxy="" no_proxy=""
+
+# unset in the systemd user session
+systemctl --user unset-environment http_proxy https_proxy HTTP_PROXY HTTPS_PROXY ftp_proxy no_proxy 2>/dev/null || true
+
+echo "Done"
+echo ""
 echo "Proxy disabled everywhere."


### PR DESCRIPTION
remove_proxy wasnt removing proxy variables from current terminal and login session, and apply_proxy was modifying ~/.bashrc to make it so that proxy variables reload for every terminal and kde login session